### PR TITLE
424-maintenance-bump-jmx2logzio-dependency-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.logz</groupId>
     <artifactId>jmx2logzio</artifactId>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
 
     <packaging>jar</packaging>
     <name>JMX2logz.io</name>
@@ -66,8 +66,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.0</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>io.logz.sender</groupId>
             <artifactId>logzio-sender</artifactId>
-            <version>1.1.1</version>
+            <version>2.4.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/logz/jmx2logzio/clients/ListenerWriter.java
+++ b/src/main/java/io/logz/jmx2logzio/clients/ListenerWriter.java
@@ -15,7 +15,6 @@ import io.logz.sender.exceptions.LogzioParameterErrorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -80,6 +79,8 @@ public class ListenerWriter implements Shutdownable {
             return senderBuilder.build();
         } catch (LogzioParameterErrorException e) {
             logger.error("problem in one or more parameters with error {}", e.getMessage(), e);
+        } catch (java.io.IOException e) {
+            logger.error("failed to build logzio sender with error {}", e.getMessage(), e);
         }
         return null;
     }
@@ -113,7 +114,6 @@ public class ListenerWriter implements Shutdownable {
     /**
      * Start a scheduled task to poll the metrics from the metrics queue and send them
      */
-    @PostConstruct
     public void start() {
         enableHangupSupport();
     }


### PR DESCRIPTION
Bump `logzio-sender` from 1.1.1 to 2.4.0.

- `logzio-sender` 2.x requires JDK 11+, so the compiler target is bumped from 8 to 11.
- Adapt `ListenerWriter` to the 2.x API: `LogzioSender.Builder.build()` now throws `IOException`, and the no-op `@PostConstruct` (removed from the JDK in 11) is dropped.
- Bump project version to 1.1.6.

Signed-off-by: Joshua Greenman <42908485+Joshua-Gr@users.noreply.github.com>